### PR TITLE
Remove labeled break

### DIFF
--- a/src/mix.ts
+++ b/src/mix.ts
@@ -138,7 +138,7 @@ class MixedParse implements PartialParse {
     let overlay: ActiveOverlay | null = null
     let covered: CoverInfo = null
     let cursor = new TreeCursor(new TreeNode(this.baseTree!, this.ranges[0].from, 0, null), Mode.Full)
-    scan: for (let nest, isCovered; this.stoppedAt == null || cursor.from < this.stoppedAt;) {
+    for (let nest, isCovered; this.stoppedAt == null || cursor.from < this.stoppedAt;) {
       let enter = true, range
       if (fragmentCursor.hasNode(cursor)) {
         if (overlay) {
@@ -180,7 +180,7 @@ class MixedParse implements PartialParse {
       } else {
         for (;;) {
           if (cursor.nextSibling()) break
-          if (!cursor.parent()) break scan
+          if (!cursor.parent()) return
           if (overlay && !--overlay.depth) {
             let ranges = punchRanges(this.ranges, overlay.ranges)
             if (ranges.length) this.inner.splice(overlay.index, 0, new InnerParse(


### PR DESCRIPTION
When building bundles with e.g. Parcel (which uses terser) or UglifyJS minification fails:

```
@parcel/optimizer-terser: Undefined label scan

  /Users/zef/git/noot/webapp/node_modules/@lezer/common/dist/index.js:1441:34
    1440 |                     if (!cursor.parent())
  > 1441 |                         break scan;
  >      |                                  ^ Undefined label scan
    1442 |                     if (overlay && !--overlay.depth) {
    1443 |                         let ranges = punchRanges(this.ranges, overlay.ranges);

```

To circumvent this, I have replaced this particular labeled break with a `return` which, from what I can deduce should be 100% equivalent to the break (in this case). Both the `break` and `return` would effectively jump out of the outer `for` loop and immediately return (with no value).